### PR TITLE
Fix Content-Disposition filename parsing

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -445,7 +445,7 @@ def main() -> None:
         sys.exit(1)
     logger.debug("Downloading to " + os.getcwd() + "...")
 
-    download_url(client, typing.cast(SCDLArgs, python_args))
+    download_url(client, typing.cast("SCDLArgs", python_args))
 
     if arguments["--remove"]:
         remove_files()
@@ -904,7 +904,7 @@ def download_original_file(
     header = r.headers.get("content-disposition")
     params = utils.parse_header(header)
     if "filename" in params:
-        filename = urllib.parse.unquote(params["filename"][-1], encoding="utf-8")
+        filename = urllib.parse.unquote(params["filename"], encoding="utf-8")
     else:
         raise MissingFilenameError(header)
 

--- a/scdl/utils.py
+++ b/scdl/utils.py
@@ -76,8 +76,17 @@ def size_in_bytes(insize: str) -> int:
 
 
 def parse_header(content_disposition: Optional[str]) -> Dict[str, str]:
+    """Parse a Content-Disposition style header into a dictionary."""
+
     if not content_disposition:
         return {}
+
     message = email.message.Message()
     message["content-type"] = content_disposition
-    return dict(message.get_params({}))
+
+    params = message.get_params()
+    if not params:
+        return {}
+
+    # Skip the first element which contains the main value (e.g. "attachment")
+    return dict(params[1:])


### PR DESCRIPTION
## Summary
- handle `Content-Disposition` headers correctly
- use parsed filename directly when downloading original tracks

## Testing
- `ruff check scdl/utils.py scdl/scdl.py`
- `mypy scdl/utils.py scdl/scdl.py` *(fails: missing stubs)*
- `pytest -q` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685727bcebc48322b2047738e944fd22