### PR TITLE
Add best-quality option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ scdl me -f
 --add-description               Adds the description to a seperate txt file (can be read by some players)
 --no-playlist                   Skip downloading playlists
 --opus                          Prefer downloading opus streams over mp3 streams
+--best-quality                  Try to download lossless audio first, converting to FLAC when
+                                available, and fall back to the next best quality
 ```
 
 

--- a/scdl/scdl.cfg
+++ b/scdl/scdl.cfg
@@ -1,7 +1,7 @@
 [scdl]
 client_id = 1JEFtFgP4Mocy0oEGJj2zZ0il9pEpBrM
 auth_token = 2-304819-165239826-USxN5UsAfVLsru
-path = C:\\Users\\emori\\Music\\SoundCloud Flacs
+path = .
 name_format = {title}
 playlist_name_format = {playlist[title]}_{title}
 

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -9,7 +9,7 @@ Usage:
     [--original-name][--original-metadata][--no-original][--only-original]
     [--name-format <format>][--strict-playlist][--playlist-name-format <format>]
     [--client-id <id>][--auth-token <token>][--overwrite][--no-playlist][--opus]
-    [--add-description]
+    [--add-description][--best-quality]
 
     scdl -h | --help
     scdl --version
@@ -72,6 +72,9 @@ Options:
     --no-playlist                   Skip downloading playlists
     --add-description               Adds the description to a separate txt file
     --opus                          Prefer downloading opus streams over mp3 streams
+    --best-quality                  Try to download lossless audio and convert to
+                                    FLAC when possible; fall back to the best
+                                    available quality otherwise
 """
 
 import atexit
@@ -180,6 +183,7 @@ class SCDLArgs(TypedDict):
     only_original: bool
     onlymp3: bool
     opus: bool
+    best_quality: bool
     original_art: bool
     original_metadata: bool
     original_name: bool
@@ -432,6 +436,10 @@ def main() -> None:
     for key, value in arguments.items():
         key = key.strip("-").replace("-", "_")
         python_args[key] = value
+
+    if python_args.get("best_quality"):
+        python_args["flac"] = True
+        python_args["opus"] = True
 
     # change download path
     dl_path: str = arguments["--path"] or config["scdl"]["path"]

--- a/scdl/utils.py
+++ b/scdl/utils.py
@@ -89,4 +89,9 @@ def parse_header(content_disposition: Optional[str]) -> Dict[str, str]:
         return {}
 
     # Skip the first element which contains the main value (e.g. "attachment")
-    return dict(params[1:])
+    parsed = {}
+    for k, v in params[1:]:
+        if isinstance(v, tuple):
+            v = v[0]
+        parsed[k] = v
+    return parsed

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -90,6 +90,20 @@ def test_flac(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not os.getenv("AUTH_TOKEN"), reason="No auth token specified")
+def test_best_quality(tmp_path: Path) -> None:
+    os.chdir(tmp_path)
+    r = call_scdl_with_auth(
+        "-l",
+        "https://soundcloud.com/violinbutterflynet/original",
+        "--name-format",
+        "track",
+        "--best-quality",
+    )
+    assert r.returncode == 0
+    assert_track(tmp_path, "track.flac", "copy", "saves", None)
+
+
+@pytest.mark.skipif(not os.getenv("AUTH_TOKEN"), reason="No auth token specified")
 def test_m4a(tmp_path: Path) -> None:
     os.chdir(tmp_path)
     r = call_scdl_with_auth(


### PR DESCRIPTION
## Summary
- add `--best-quality` CLI flag to automatically prefer FLAC/Opus
- document flag in README
- tweak default config path for tests
- fix handling of tuple values when parsing headers
- test new flag

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573910267c83229e94d36166790847