### PR TITLE
Fix Opus/OGG cover art metadata and stabilize `me all` preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ scdl -l https://soundcloud.com/pandadub/sets/the-lost-ship --sync archive.txt
 
 # Download your likes (with authentification token)
 scdl me -f
+
+# Download all your likes with quality/retry/archive defaults
+scdl me all
 ```
 
 ## Options:
@@ -53,6 +56,8 @@ scdl me -f
 -C                              Download all tracks commented on by a user
 -p                              Download all playlists of a user
 -r                              Download all reposts of user
+all                             Download all likes with best-quality,
+                                retries and archive defaults
 -c                              Continue if a downloaded file already exists
 --force-metadata                This will set metadata on already downloaded track
 -o [offset]                     Start downloading a playlist from the [offset]th track (starting with 1)

--- a/scdl/metadata_assembler.py
+++ b/scdl/metadata_assembler.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 from dataclasses import dataclass
 from functools import singledispatch
-from typing import Optional, Union
+from typing import Optional, Protocol, Union
 
 from mutagen import (
     FileType,
@@ -17,6 +17,10 @@ from mutagen import (
 )
 
 JPEG_MIME_TYPE: str = "image/jpeg"
+
+
+class ArtworkTagWriter(Protocol):
+    def __setitem__(self, key: str, value: object) -> None: ...
 
 
 @dataclass(frozen=True)
@@ -89,6 +93,21 @@ def _assemble_vorbis_tags(file: FileType, meta: MetadataInfo) -> None:
         file["description"] = meta.description
 
 
+def _assemble_vorbis_artwork_tags(file: ArtworkTagWriter, jpeg_data: bytes) -> None:
+    """Write artwork tags for OGG/Vorbis-based containers.
+
+    METADATA_BLOCK_PICTURE is the modern standard, while `coverart`/`coverartmime`
+    improve compatibility with players that still rely on legacy conventions.
+    """
+    pic = _get_flac_pic(jpeg_data).write()
+    pic_b64 = b64encode(pic).decode()
+    jpeg_b64 = b64encode(jpeg_data).decode()
+
+    file["metadata_block_picture"] = [pic_b64]
+    file["coverart"] = [jpeg_b64]
+    file["coverartmime"] = [JPEG_MIME_TYPE]
+
+
 @assemble_metadata.register(flac.FLAC)
 def _(file: flac.FLAC, meta: MetadataInfo) -> None:
     _assemble_vorbis_tags(file, meta)
@@ -104,8 +123,7 @@ def _(file: oggopus.OggOpus, meta: MetadataInfo) -> None:
     _assemble_vorbis_tags(file, meta)
 
     if meta.artwork_jpeg:
-        pic = _get_flac_pic(meta.artwork_jpeg).write()
-        file["metadata_block_picture"] = b64encode(pic).decode()
+        _assemble_vorbis_artwork_tags(file, meta.artwork_jpeg)
 
 
 @assemble_metadata.register(aiff.AIFF)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1,7 +1,7 @@
 """scdl allows you to download music from Soundcloud
 
 Usage:
-    scdl (-l <track_url> | -s <search_query> | me) [-a | -f | -C | -t | -p | -r]
+    scdl (-l <track_url> | -s <search_query> | me [all]) [-a | -f | -C | -t | -p | -r]
     [-c | --force-metadata][-n <maxtracks>][-o <offset>][--hidewarnings][--debug | --error]
     [--path <path>][--addtofile][--addtimestamp][--onlymp3][--hide-progress][--min-size <size>]
     [--max-size <size>][--remove][--no-album-tag][--no-playlist-folder]
@@ -28,6 +28,8 @@ Options:
     -C                              Download all tracks commented on by a user
     -p                              Download all playlists of a user
     -r                              Download all reposts of user
+    all                            Download all likes with best-quality,
+                                    retries and archive defaults
     -c                              Continue if a downloaded file already exists
     --force-metadata                This will set metadata on already downloaded track
     -o [offset]                     Start downloading a playlist from the [offset]th track
@@ -100,9 +102,25 @@ import typing
 import urllib.parse
 import warnings
 from dataclasses import asdict
+
+if sys.platform == "win32":
+    import msvcrt
+
 from functools import lru_cache
 from types import TracebackType
-from typing import IO, Generator, List, NoReturn, Optional, Set, Tuple, Type, Union
+from typing import (
+    IO,
+    Any,
+    Generator,
+    List,
+    MutableMapping,
+    NoReturn,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 from tqdm import tqdm
 
@@ -160,8 +178,8 @@ def setup_requests_session(retries: int) -> None:
     adapter = HTTPAdapter(max_retries=strategy)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
-    requests.get = session.get  # type: ignore[attr-defined]
-    requests.post = session.post  # type: ignore[attr-defined]
+    requests.get = session.get  # type: ignore[attr-defined,assignment]
+    requests.post = session.post  # type: ignore[attr-defined,assignment]
 
 
 class SCDLArgs(TypedDict):
@@ -198,6 +216,7 @@ class SCDLArgs(TypedDict):
     onlymp3: bool
     opus: bool
     best_quality: bool
+    all: bool
     list_qualities: bool
     original_art: bool
     original_metadata: bool
@@ -322,12 +341,30 @@ def get_filelock(path: Union[pathlib.Path, str], timeout: int = 10) -> SafeLock:
     return SafeLock(lock_path, timeout=timeout)
 
 
+def apply_all_command_defaults(arguments: MutableMapping[str, Any]) -> None:
+    """Apply `me all` preset defaults without overriding explicit user values."""
+    if not arguments.get("all"):
+        return
+
+    arguments["-f"] = True
+    arguments["--best-quality"] = True
+    arguments["-c"] = True
+
+    if not arguments.get("--retries"):
+        arguments["--retries"] = "3"
+
+    if not arguments.get("--download-archive"):
+        arguments["--download-archive"] = "archive.txt"
+
+
 def main() -> None:
     """Main function, parses the URL from command line arguments"""
     logger.addHandler(logging.StreamHandler())
 
     # Parse arguments
     arguments = docopt(__doc__, version=__version__)
+
+    apply_all_command_defaults(arguments)
 
     if arguments["--debug"]:
         logger.level = logging.DEBUG
@@ -872,8 +909,6 @@ def is_downloading_to_stdout(kwargs: SCDLArgs) -> bool:
 def get_stdout() -> Generator[IO, None, None]:
     # Credits: https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/utils/_utils.py#L575
     if sys.platform == "win32":
-        import msvcrt
-
         # stdout may be any IO stream, e.g. when using contextlib.redirect_stdout
         with contextlib.suppress(io.UnsupportedOperation):
             msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)

--- a/tests/test_cli_presets.py
+++ b/tests/test_cli_presets.py
@@ -1,0 +1,55 @@
+from scdl.scdl import apply_all_command_defaults
+
+
+def test_apply_all_command_defaults_sets_expected_flags() -> None:
+    arguments = {
+        "all": True,
+        "-f": False,
+        "--best-quality": False,
+        "-c": False,
+        "--retries": None,
+        "--download-archive": None,
+    }
+
+    apply_all_command_defaults(arguments)
+
+    assert arguments["-f"] is True
+    assert arguments["--best-quality"] is True
+    assert arguments["-c"] is True
+    assert arguments["--retries"] == "3"
+    assert arguments["--download-archive"] == "archive.txt"
+
+
+def test_apply_all_command_defaults_keeps_explicit_values() -> None:
+    arguments = {
+        "all": True,
+        "-f": False,
+        "--best-quality": False,
+        "-c": False,
+        "--retries": "7",
+        "--download-archive": "custom-archive.txt",
+    }
+
+    apply_all_command_defaults(arguments)
+
+    assert arguments["--retries"] == "7"
+    assert arguments["--download-archive"] == "custom-archive.txt"
+
+
+def test_apply_all_command_defaults_noop_when_all_disabled() -> None:
+    arguments = {
+        "all": False,
+        "-f": False,
+        "--best-quality": False,
+        "-c": False,
+        "--retries": None,
+        "--download-archive": None,
+    }
+
+    apply_all_command_defaults(arguments)
+
+    assert arguments["-f"] is False
+    assert arguments["--best-quality"] is False
+    assert arguments["-c"] is False
+    assert arguments["--retries"] is None
+    assert arguments["--download-archive"] is None

--- a/tests/test_metadata_assembler.py
+++ b/tests/test_metadata_assembler.py
@@ -1,0 +1,22 @@
+from base64 import b64decode
+
+from scdl.metadata_assembler import JPEG_MIME_TYPE, _assemble_vorbis_artwork_tags
+
+
+def test_assemble_vorbis_artwork_tags_writes_compat_keys() -> None:
+    tags: dict[str, object] = {}
+    jpeg_data = b"jpeg-bytes"
+
+    _assemble_vorbis_artwork_tags(tags, jpeg_data)
+
+    assert "metadata_block_picture" in tags
+    assert "coverart" in tags
+    assert "coverartmime" in tags
+
+    coverart = tags["coverart"]
+    assert isinstance(coverart, list)
+    assert b64decode(coverart[0]) == jpeg_data
+
+    coverartmime = tags["coverartmime"]
+    assert isinstance(coverartmime, list)
+    assert coverartmime[0] == JPEG_MIME_TYPE


### PR DESCRIPTION
### Motivation
- Opus/OGG downloads were missing robust cover art metadata support and some players expect legacy Vorbis tags in addition to `METADATA_BLOCK_PICTURE`.
- The `me all` shortcut should bundle common presets but must not clobber explicit user-provided values like `--retries` or `--download-archive`.
- Clean up a lint warning around the Windows `msvcrt` import to satisfy tooling.

### Description
- Add `_assemble_vorbis_artwork_tags` and an `ArtworkTagWriter` `Protocol` and call it for OGG/Opus containers so both `metadata_block_picture` and legacy `coverart`/`coverartmime` tags are written when artwork is present (`scdl/metadata_assembler.py`).
- Extract `me all` behavior into `apply_all_command_defaults(arguments: MutableMapping[str, Any])` which applies `-f`, `--best-quality`, `-c` and default `--retries`/`--download-archive` only when those were not explicitly provided (`scdl/scdl.py`).
- Move the Windows `msvcrt` import into a guarded top-level import and keep the binary stdout handling logic intact to satisfy `ruff`.
- Update `README.md` to document the `scdl me all` usage and options.
- Add unit tests for the new preset helper (`tests/test_cli_presets.py`) and for Vorbis artwork tag writing (`tests/test_metadata_assembler.py`).

### Testing
- Ran linting with `ruff` on the modified files; `ruff` checks passed for the updated files.
- Ran type checks with `mypy` for the package and new tests; `mypy` passed for the checked modules.
- Ran unit tests for the new functionality with `pytest -q tests/test_cli_presets.py tests/test_metadata_assembler.py`; those tests passed (`4 passed`).
- Ran the full test suite with `pytest -q`; this environment produced integration failures (`26 failed, 11 passed, 10 skipped`) due to missing runtime dependencies (`ffmpeg` not installed) and intermittent upstream SoundCloud API errors (502), not due to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_68591ab5e2708322b559cdae3b5ae291)